### PR TITLE
Remove manual adding of X-CSRF-TOKEN header (#5083)

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -24,20 +24,6 @@ window.axios = require('axios');
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 /**
- * Next we will register the CSRF Token as a common header with Axios so that
- * all outgoing HTTP requests automatically have it attached. This is just
- * a simple convenience so we don't have to attach every token manually.
- */
-
-let token = document.head.querySelector('meta[name="csrf-token"]');
-
-if (token) {
-    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
-} else {
-    console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
-}
-
-/**
  * Echo exposes an expressive API for subscribing to channels and listening
  * for events that are broadcast by Laravel. Echo and event broadcasting
  * allows your team to easily build robust real-time web applications.


### PR DESCRIPTION
This is unnessecery code because Axios already automatically adds
a X-XSRF-TOKEN header from the XSRF-TOKEN cookie encrypted value on
same-origin requests. The `VerifyCsrfToken` middleware and Passport's
`TokenGuard` already allow using the `X-XSRF-TOKEN` header.